### PR TITLE
Fix minimum macOS version in Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftDataX",
     platforms: [
         .iOS(.v18),
-        .macOS(.v14)
+        .macOS(.v14_4)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftDataX",
     platforms: [
         .iOS(.v18),
-        .macOS(.v14_4)
+        .macOS("14.4")
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftDataX",
     platforms: [
         .iOS(.v18),
-        .macOS(.v10_15)
+        .macOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
SwiftDataX can only compile in projects targeting macOS 14.4 or newer.